### PR TITLE
Fixed Nuget Package

### DIFF
--- a/source/Scribbly.Stencil.Generator/Scribbly.Stencil.Generator.csproj
+++ b/source/Scribbly.Stencil.Generator/Scribbly.Stencil.Generator.csproj
@@ -6,13 +6,18 @@
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <NoWarn>NU5128</NoWarn>
-        <GenerateDocumentationFile>False</GenerateDocumentationFile>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
     
 </Project>


### PR DESCRIPTION
# Scribbly Pull Request

## Description

Source Generator csproj was missing required analyzer configuration.

```xml
<IncludeBuildOutput>false</IncludeBuildOutput>
<ItemGroup>
        <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
    </ItemGroup>
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have executed all the unit tests
- [x] I have compiled and executed the application
- [x] I have updated the documentation to reflect my changes

## Github Issues

closes #13 