### PR TITLE
Rolled Back Microsoft.CodeAnalysis.Analyzers to v4.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,12 +6,12 @@
     <!-- CODE GENERATOR -->
 
   <ItemGroup >
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
# Scribbly Pull Request

## Description

To support build pipelines running dotnet 8 SDK the Microsoft.CodeAnalysis.Analyzers v4.14.0 was rolled back to v4.11.0.  This should be temporary until I sort out how I want this to behave. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have executed all the unit tests
- [x] I have compiled and executed the application
- [x] I have updated the documentation to reflect my changes

## Github Issues

closes #30 