### PR TITLE
Adds Multi Targets for Roslyn Dotnet SDKs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,14 +8,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.10.4" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.10.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,14 +8,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.10.4" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.10.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,20 +2,37 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  <!-- Dependencies per target -->
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+  </ItemGroup>
+  
   <!-- CODE GENERATOR -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.10.4" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.10.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.2" />

--- a/source/Scribbly.Stencil.Analyzer/Scribbly.Stencil.Analyzer.csproj
+++ b/source/Scribbly.Stencil.Analyzer/Scribbly.Stencil.Analyzer.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 

--- a/source/Scribbly.Stencil/Scribbly.Stencil.csproj
+++ b/source/Scribbly.Stencil/Scribbly.Stencil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 <!--
@@ -21,15 +21,39 @@
           Pack="true"
           PackagePath="analyzers/dotnet/cs"
           Visible="false" />
+    <None Include="..\Scribbly.Stencil.Generator\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Generator.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet8.0/cs"
+          Visible="false" />
+    <None Include="..\Scribbly.Stencil.Generator\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Generator.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet9.0/cs"
+          Visible="false" />
     
     <None Include="..\Scribbly.Stencil.Analyzer\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.dll"
           Pack="true"
           PackagePath="analyzers/dotnet/cs"
           Visible="false" />
+    <None Include="..\Scribbly.Stencil.Analyzer\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet8.0/cs"
+          Visible="false" />
+    <None Include="..\Scribbly.Stencil.Analyzer\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet9.0/cs"
+          Visible="false" />
 
     <None Include="..\Scribbly.Stencil.Analyzer.CodeFixes\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.CodeFixes.dll"
           Pack="true"
           PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="..\Scribbly.Stencil.Analyzer.CodeFixes\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.CodeFixes.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet8.0/cs"
+          Visible="false" />
+    <None Include="..\Scribbly.Stencil.Analyzer.CodeFixes\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.CodeFixes.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet9.0/cs"
           Visible="false" />
 
   </ItemGroup>

--- a/source/Scribbly.Stencil/Scribbly.Stencil.csproj
+++ b/source/Scribbly.Stencil/Scribbly.Stencil.csproj
@@ -19,29 +19,17 @@
   <ItemGroup Condition="'$(IsPacking)' == 'true'">
     <None Include="..\Scribbly.Stencil.Generator\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Generator.dll"
           Pack="true"
-          PackagePath="analyzers/roslyn4.11/cs"
-          Visible="false" />
-    <None Include="..\Scribbly.Stencil.Generator\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Generator.dll"
-          Pack="true"
-          PackagePath="analyzers/roslyn4.14/cs"
+          PackagePath="analyzers/dotnet/cs"
           Visible="false" />
     
     <None Include="..\Scribbly.Stencil.Analyzer\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.dll"
           Pack="true"
-          PackagePath="analyzers/roslyn4.11/cs"
-          Visible="false" />
-    <None Include="..\Scribbly.Stencil.Analyzer\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.dll"
-          Pack="true"
-          PackagePath="analyzers/roslyn4.14/cs"
+          PackagePath="analyzers/dotnet/cs"
           Visible="false" />
     
     <None Include="..\Scribbly.Stencil.Analyzer.CodeFixes\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.CodeFixes.dll"
           Pack="true"
-          PackagePath="analyzers/roslyn4.11/cs"
-          Visible="false" />
-    <None Include="..\Scribbly.Stencil.Analyzer.CodeFixes\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.CodeFixes.dll"
-          Pack="true"
-          PackagePath="analyzers/roslyn4.14/cs"
+          PackagePath="analyzers/dotnet/cs"
           Visible="false" />
 
   </ItemGroup>

--- a/source/Scribbly.Stencil/Scribbly.Stencil.csproj
+++ b/source/Scribbly.Stencil/Scribbly.Stencil.csproj
@@ -19,41 +19,29 @@
   <ItemGroup Condition="'$(IsPacking)' == 'true'">
     <None Include="..\Scribbly.Stencil.Generator\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Generator.dll"
           Pack="true"
-          PackagePath="analyzers/dotnet/cs"
+          PackagePath="analyzers/roslyn4.11/cs"
           Visible="false" />
     <None Include="..\Scribbly.Stencil.Generator\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Generator.dll"
           Pack="true"
-          PackagePath="analyzers/dotnet8.0/cs"
-          Visible="false" />
-    <None Include="..\Scribbly.Stencil.Generator\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Generator.dll"
-          Pack="true"
-          PackagePath="analyzers/dotnet9.0/cs"
+          PackagePath="analyzers/roslyn4.14/cs"
           Visible="false" />
     
     <None Include="..\Scribbly.Stencil.Analyzer\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.dll"
           Pack="true"
-          PackagePath="analyzers/dotnet/cs"
+          PackagePath="analyzers/roslyn4.11/cs"
           Visible="false" />
     <None Include="..\Scribbly.Stencil.Analyzer\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.dll"
           Pack="true"
-          PackagePath="analyzers/dotnet8.0/cs"
+          PackagePath="analyzers/roslyn4.14/cs"
           Visible="false" />
-    <None Include="..\Scribbly.Stencil.Analyzer\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.dll"
-          Pack="true"
-          PackagePath="analyzers/dotnet9.0/cs"
-          Visible="false" />
-
+    
     <None Include="..\Scribbly.Stencil.Analyzer.CodeFixes\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.CodeFixes.dll"
           Pack="true"
-          PackagePath="analyzers/dotnet/cs"
+          PackagePath="analyzers/roslyn4.11/cs"
           Visible="false" />
     <None Include="..\Scribbly.Stencil.Analyzer.CodeFixes\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.CodeFixes.dll"
           Pack="true"
-          PackagePath="analyzers/dotnet8.0/cs"
-          Visible="false" />
-    <None Include="..\Scribbly.Stencil.Analyzer.CodeFixes\bin\$(Configuration)\netstandard2.0\Scribbly.Stencil.Analyzer.CodeFixes.dll"
-          Pack="true"
-          PackagePath="analyzers/dotnet9.0/cs"
+          PackagePath="analyzers/roslyn4.14/cs"
           Visible="false" />
 
   </ItemGroup>

--- a/tests/Scribbly.Stencil.Analyzer.Test/Scribbly.Stencil.Analyzer.Test.csproj
+++ b/tests/Scribbly.Stencil.Analyzer.Test/Scribbly.Stencil.Analyzer.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
 
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/tests/Scribbly.Stencil.Analyzer.Test/Scribbly.Stencil.Analyzer.Test.csproj
+++ b/tests/Scribbly.Stencil.Analyzer.Test/Scribbly.Stencil.Analyzer.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/tests/Scribbly.Stencil.UnitTests/Scribbly.Stencil.UnitTests.csproj
+++ b/tests/Scribbly.Stencil.UnitTests/Scribbly.Stencil.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Scribbly.Stencil.UnitTests/Scribbly.Stencil.UnitTests.csproj
+++ b/tests/Scribbly.Stencil.UnitTests/Scribbly.Stencil.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
# Scribbly Pull Request

## Description

To support legacy builds using dotnet 8 SDKs multiple targets have been configured to ensure a machine running the dotnet 8 SDK can build a project using Stencil.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have executed all the unit tests
- [x] I have compiled and executed the application
- [x] I have updated the documentation to reflect my changes

## Github Issues

closes #26 